### PR TITLE
fix: make Google project ID mandatory and add model dropdowns

### DIFF
--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ProviderSettingsView.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ProviderSettingsView.swift
@@ -22,6 +22,13 @@ struct ProviderSettingsView: View {
                 .textContentType(.password)
             TextField("Voice ID", text: $viewModel.elevenLabsVoiceID)
                 .textContentType(.none)
+            Picker("Model", selection: $viewModel.elevenLabsModelID) {
+                Text("Eleven Flash v2.5").tag("eleven_flash_v2_5")
+                Text("Eleven Flash v2").tag("eleven_flash_v2")
+                Text("Eleven Multilingual v2").tag("eleven_multilingual_v2")
+                Text("Eleven Turbo v2.5").tag("eleven_turbo_v2_5")
+                Text("Eleven Turbo v2").tag("eleven_turbo_v2")
+            }
         }
     }
 
@@ -35,9 +42,16 @@ struct ProviderSettingsView: View {
             Text("Run `gcloud auth print-access-token` in Terminal")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            TextField("Language Code", text: $viewModel.googleLanguageCode)
-            TextField("Voice Name", text: $viewModel.googleVoiceName)
-            TextField("Project ID (optional)", text: $viewModel.googleProjectID)
+            Picker("Voice (Model)", selection: $viewModel.googleVoiceName) {
+                Text("Chirp 3 HD Achernar (en-US-Chirp3-HD-Achernar)").tag("en-US-Chirp3-HD-Achernar")
+                Text("Chirp 3 HD Aoede (en-US-Chirp3-HD-Aoede)").tag("en-US-Chirp3-HD-Aoede")
+                Text("Journey D (en-US-Journey-D)").tag("en-US-Journey-D")
+                Text("Journey F (en-US-Journey-F)").tag("en-US-Journey-F")
+                Text("Journey O (en-US-Journey-O)").tag("en-US-Journey-O")
+                Text("Neural2 F (en-US-Neural2-F)").tag("en-US-Neural2-F")
+                Text("Neural2 J (en-US-Neural2-J)").tag("en-US-Neural2-J")
+            }
+            TextField("Project ID", text: $viewModel.googleProjectID)
         }
     }
 }

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/TTSViewModel.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/TTSViewModel.swift
@@ -39,13 +39,26 @@ final class TTSViewModel {
 
     @ObservationIgnored
     @AppStorage("elevenLabsVoiceID") var elevenLabsVoiceID: String = "21m00Tcm4TlvDq8ikWAM"
+    
+    @ObservationIgnored
+    @AppStorage("elevenLabsModelID") var elevenLabsModelID: String = "eleven_flash_v2_5"
 
     // MARK: - Google Cloud settings (tokens are short-lived, not persisted)
 
     var googleAccessToken: String = ""
-    var googleLanguageCode: String = "en-US"
     var googleVoiceName: String = "en-US-Chirp3-HD-Achernar"
-    var googleProjectID: String = ""
+    
+    var googleLanguageCode: String {
+        // Extract language code from voice name (e.g. "en-US" from "en-US-Chirp3-HD-Achernar")
+        let components = googleVoiceName.split(separator: "-")
+        if components.count >= 2 {
+            return "\(components[0])-\(components[1])"
+        }
+        return "en-US"
+    }
+    
+    @ObservationIgnored
+    @AppStorage("googleProjectID") var googleProjectID: String = ""
 
     // MARK: - Playback state
 
@@ -69,7 +82,7 @@ final class TTSViewModel {
         case .elevenLabs:
             return !elevenLabsAPIKey.isEmpty && !elevenLabsVoiceID.isEmpty
         case .googleCloud:
-            return !googleAccessToken.isEmpty
+            return !googleAccessToken.isEmpty && !googleProjectID.isEmpty
         }
     }
 
@@ -136,11 +149,12 @@ final class TTSViewModel {
         guard !googleAccessToken.isEmpty else {
             throw ValidationError.missingCredentials("Google access token is required.")
         }
+        guard !googleProjectID.isEmpty else {
+            throw ValidationError.missingCredentials("Google Project ID is required.")
+        }
         var config = GoogleCloudTTSConfiguration()
         config.voice = .init(languageCode: googleLanguageCode, name: googleVoiceName)
-        if !googleProjectID.isEmpty {
-            config.quotaProjectID = googleProjectID
-        }
+        config.quotaProjectID = googleProjectID
         let auth = PastedTokenAuthProvider(token: googleAccessToken)
         return GoogleCloudTTSAdapter(configuration: config, authProvider: auth)
     }
@@ -151,10 +165,11 @@ final class TTSViewModel {
             guard !elevenLabsAPIKey.isEmpty else {
                 throw ValidationError.missingCredentials("ElevenLabs API key is required.")
             }
-            let config = ElevenLabsConfiguration(
+            var config = ElevenLabsConfiguration(
                 apiKey: elevenLabsAPIKey,
                 voiceId: elevenLabsVoiceID
             )
+            config.modelId = elevenLabsModelID
             return ElevenLabsTTSAdapter(configuration: config)
 
         case .googleCloud:


### PR DESCRIPTION
## Summary
- Made the Project ID field mandatory for Google Cloud TTS to prevent silent stream failures
- Added model selection dropdown for ElevenLabs using recent models
- Added model selection dropdown for Google Cloud TTS (voices)
- Derived Google language code directly from the selected voice name

Fixes #19