### PR TITLE
chore: release dev to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ See `Sources/StreamTTSElevenLabs/` for a complete reference implementation using
 1. Fork the repository and create a feature branch.
 2. Make your changes in focused, atomic commits.
 3. Ensure `swift build` and `swift test` pass locally.
-4. Open a PR against `main`. Include a description of what changed and why.
+4. Open a PR against `dev`. Include a description of what changed and why.
 5. All PRs must pass CI checks before merging.
 6. Include tests for new functionality.
 

--- a/Examples/StreamTTSDemo/Package.resolved
+++ b/Examples/StreamTTSDemo/Package.resolved
@@ -1,0 +1,203 @@
+{
+  "pins" : [
+    {
+      "identity" : "grpc-swift-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
+      "state" : {
+        "revision" : "f28854bc760a116e053fdfc4a48a9428c34625c0",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "3ca4136b4426b3f87ca1d98e3b0939724025a202",
+        "version" : "2.6.1"
+      }
+    },
+    {
+      "identity" : "grpc-swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state" : {
+        "revision" : "0b53365d87cb79aed6e9c509f947eb96ba0d3da6",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
+        "version" : "4.3.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
+        "version" : "1.33.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
+        "version" : "1.42.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
+        "version" : "2.36.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Examples/StreamTTSDemo/Package.swift
+++ b/Examples/StreamTTSDemo/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "StreamTTSDemo",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(name: "StreamTTS", path: "../.."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "StreamTTSDemo",
+            dependencies: [
+                .product(name: "StreamTTSCore", package: "StreamTTS"),
+                .product(name: "StreamTTSElevenLabs", package: "StreamTTS"),
+                .product(name: "StreamTTSGoogleCloud", package: "StreamTTS"),
+            ]
+        ),
+    ]
+)

--- a/Examples/StreamTTSDemo/README.md
+++ b/Examples/StreamTTSDemo/README.md
@@ -1,0 +1,55 @@
+# StreamTTS Demo
+
+A minimal macOS SwiftUI app for testing the StreamTTS library with real credentials.
+
+## Prerequisites
+
+- macOS 14+ (Sonoma or later)
+- Xcode 15+
+- An **ElevenLabs API key** and/or a **Google Cloud access token**
+
+## Running the Demo
+
+Open the demo package in Xcode:
+
+```bash
+open Examples/StreamTTSDemo/Package.swift
+```
+
+Xcode will resolve the local StreamTTS dependency automatically (it references the repo root via `../..`). Select the `StreamTTSDemo` scheme and press **Cmd+R** to build and run.
+
+Alternatively, build and run from the command line:
+
+```bash
+cd Examples/StreamTTSDemo
+swift run StreamTTSDemo
+```
+
+## Getting Credentials
+
+### ElevenLabs
+
+1. Sign up at [elevenlabs.io](https://elevenlabs.io)
+2. Go to **Profile > API Keys** and copy your key
+3. Paste the key into the "API Key" field in the app
+4. The default Voice ID (`21m00Tcm4TlvDq8ikWAM`) is "Rachel"
+
+### Google Cloud
+
+1. Install the [gcloud CLI](https://cloud.google.com/sdk/docs/install)
+2. Run `gcloud auth print-access-token` in Terminal
+3. Paste the token into the "Access Token" field
+4. Tokens expire after ~1 hour; generate a fresh one when needed
+5. If using user credentials (not a service account), you must also fill in your **Project ID** for quota attribution
+
+**Note:** Google Cloud TTS streaming requires macOS 15.0+ at runtime due to grpc-swift v2 transport requirements.
+
+## Usage
+
+1. Select a provider (ElevenLabs or Google Cloud)
+2. Enter your credentials
+3. Type or paste text into the text area
+4. Press **Speak** (or Cmd+Return) to start streaming playback
+5. Press **Stop** (or Cmd+.) to cancel mid-stream
+
+The app breaks your text into sentences and yields them with short delays to simulate real-time LLM streaming output.

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ContentView.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ContentView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// Main window layout: provider picker, settings, text input, and playback controls.
+struct ContentView: View {
+    @State private var viewModel = TTSViewModel()
+
+    var body: some View {
+        Form {
+            // MARK: - Provider picker
+            Section("Provider") {
+                Picker("Provider", selection: $viewModel.selectedProvider) {
+                    ForEach(ProviderType.allCases) { provider in
+                        Text(provider.rawValue).tag(provider)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+
+            // MARK: - Provider-specific settings
+            ProviderSettingsView(viewModel: viewModel)
+
+            // MARK: - Text input
+            Section("Text to Speak") {
+                TextEditor(text: $viewModel.inputText)
+                    .frame(minHeight: 100)
+                    .font(.body)
+            }
+
+            // MARK: - Controls
+            Section {
+                HStack {
+                    statusLabel
+                    Spacer()
+                    if viewModel.isPlaying {
+                        Button("Stop") {
+                            viewModel.stop()
+                        }
+                        .keyboardShortcut(".", modifiers: .command)
+                    }
+                    Button("Speak") {
+                        viewModel.speak()
+                    }
+                    .keyboardShortcut(.return, modifiers: .command)
+                    .disabled(!viewModel.canSpeak)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+
+    // MARK: - Status display
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch viewModel.status {
+        case .ready:
+            Text("Ready")
+                .foregroundStyle(.secondary)
+        case .connecting:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Connecting...")
+            }
+        case .streaming:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Streaming...")
+            }
+        case .playing:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Playing...")
+            }
+        case .finished:
+            Text("Finished")
+                .foregroundStyle(.green)
+        case .error(let message):
+            Text(message)
+                .foregroundStyle(.red)
+                .lineLimit(2)
+                .help(message)
+        }
+    }
+}

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/PastedTokenAuthProvider.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/PastedTokenAuthProvider.swift
@@ -1,0 +1,11 @@
+import StreamTTSGoogleCloud
+
+/// A simple auth provider that returns a user-pasted OAuth2 access token.
+///
+/// Use this with tokens obtained from `gcloud auth print-access-token`.
+/// Tokens expire after ~1 hour; paste a fresh one when needed.
+struct PastedTokenAuthProvider: GoogleAuthProvider {
+    let token: String
+
+    func accessToken() async throws -> String { token }
+}

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ProviderSettingsView.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ProviderSettingsView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Credential and configuration forms for each TTS provider.
+struct ProviderSettingsView: View {
+    @Bindable var viewModel: TTSViewModel
+
+    var body: some View {
+        switch viewModel.selectedProvider {
+        case .elevenLabs:
+            elevenLabsSettings
+        case .googleCloud:
+            googleCloudSettings
+        }
+    }
+
+    // MARK: - ElevenLabs
+
+    @ViewBuilder
+    private var elevenLabsSettings: some View {
+        Section("ElevenLabs Credentials") {
+            SecureField("API Key", text: $viewModel.elevenLabsAPIKey)
+                .textContentType(.password)
+            TextField("Voice ID", text: $viewModel.elevenLabsVoiceID)
+                .textContentType(.none)
+        }
+    }
+
+    // MARK: - Google Cloud
+
+    @ViewBuilder
+    private var googleCloudSettings: some View {
+        Section("Google Cloud Credentials") {
+            TextField("Access Token", text: $viewModel.googleAccessToken)
+                .textContentType(.none)
+            Text("Run `gcloud auth print-access-token` in Terminal")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            TextField("Language Code", text: $viewModel.googleLanguageCode)
+            TextField("Voice Name", text: $viewModel.googleVoiceName)
+            TextField("Project ID (optional)", text: $viewModel.googleProjectID)
+        }
+    }
+}

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ProviderSettingsView.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/ProviderSettingsView.swift
@@ -22,6 +22,13 @@ struct ProviderSettingsView: View {
                 .textContentType(.password)
             TextField("Voice ID", text: $viewModel.elevenLabsVoiceID)
                 .textContentType(.none)
+            Picker("Model", selection: $viewModel.elevenLabsModelID) {
+                Text("Eleven Flash v2.5").tag("eleven_flash_v2_5")
+                Text("Eleven Flash v2").tag("eleven_flash_v2")
+                Text("Eleven Multilingual v2").tag("eleven_multilingual_v2")
+                Text("Eleven Turbo v2.5").tag("eleven_turbo_v2_5")
+                Text("Eleven Turbo v2").tag("eleven_turbo_v2")
+            }
         }
     }
 
@@ -35,9 +42,16 @@ struct ProviderSettingsView: View {
             Text("Run `gcloud auth print-access-token` in Terminal")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            TextField("Language Code", text: $viewModel.googleLanguageCode)
-            TextField("Voice Name", text: $viewModel.googleVoiceName)
-            TextField("Project ID (optional)", text: $viewModel.googleProjectID)
+            Picker("Voice (Model)", selection: $viewModel.googleVoiceName) {
+                Text("Chirp 3 HD Achernar (en-US-Chirp3-HD-Achernar)").tag("en-US-Chirp3-HD-Achernar")
+                Text("Chirp 3 HD Aoede (en-US-Chirp3-HD-Aoede)").tag("en-US-Chirp3-HD-Aoede")
+                Text("Journey D (en-US-Journey-D)").tag("en-US-Journey-D")
+                Text("Journey F (en-US-Journey-F)").tag("en-US-Journey-F")
+                Text("Journey O (en-US-Journey-O)").tag("en-US-Journey-O")
+                Text("Neural2 F (en-US-Neural2-F)").tag("en-US-Neural2-F")
+                Text("Neural2 J (en-US-Neural2-J)").tag("en-US-Neural2-J")
+            }
+            TextField("Project ID", text: $viewModel.googleProjectID)
         }
     }
 }

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/StreamTTSDemoApp.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/StreamTTSDemoApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// StreamTTS Demo — a minimal macOS app for testing streaming text-to-speech.
+@main
+struct StreamTTSDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .frame(minWidth: 550, minHeight: 450)
+        }
+        .defaultSize(width: 600, height: 500)
+    }
+}

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/StreamTTSDemoApp.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/StreamTTSDemoApp.swift
@@ -17,12 +17,33 @@ struct StreamTTSDemoApp: App {
     }
 }
 
-/// Ensures the app becomes the frontmost process on launch.
+/// Ensures the app becomes a regular GUI application and receives keyboard focus.
 ///
-/// Without this, `swift run` launches the window but macOS keeps keyboard
-/// focus on the terminal/browser that was previously active.
+/// SPM executables lack an `.app` bundle and `Info.plist`, so macOS does not
+/// automatically treat them as regular GUI applications. Without explicitly
+/// setting the activation policy to `.regular`, the window appears but keyboard
+/// input is routed to the previously active app (Terminal, browser, etc.).
+/// The "Cannot index window tabs due to missing main bundle identifier" log
+/// is a cosmetic side-effect of the missing bundle — harmless but unavoidable
+/// for pure SPM executables.
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        // Register as a regular foreground application *before* the UI is set up.
+        // Without this, macOS treats the process as a background/accessory app
+        // and never routes keyboard events to its windows.
+        NSApp.setActivationPolicy(.regular)
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        // Bring the app to the foreground.
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        // Make the first eligible window the key window so it receives keyboard input.
+        // This covers initial launch and reactivation (e.g. clicking the Dock icon).
+        if let window = NSApp.windows.first(where: { $0.canBecomeKey }) {
+            window.makeKeyAndOrderFront(nil)
+        }
     }
 }

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/StreamTTSDemoApp.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/StreamTTSDemoApp.swift
@@ -1,13 +1,28 @@
 import SwiftUI
+import AppKit
 
 /// StreamTTS Demo — a minimal macOS app for testing streaming text-to-speech.
 @main
 struct StreamTTSDemoApp: App {
+    /// Delegate that activates the app on launch so it receives keyboard focus
+    /// even when started from the terminal via `swift run`.
+    @NSApplicationDelegateAdaptor private var appDelegate: AppDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .frame(minWidth: 550, minHeight: 450)
         }
         .defaultSize(width: 600, height: 500)
+    }
+}
+
+/// Ensures the app becomes the frontmost process on launch.
+///
+/// Without this, `swift run` launches the window but macOS keeps keyboard
+/// focus on the terminal/browser that was previously active.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 }

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/TTSViewModel.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/TTSViewModel.swift
@@ -39,13 +39,26 @@ final class TTSViewModel {
 
     @ObservationIgnored
     @AppStorage("elevenLabsVoiceID") var elevenLabsVoiceID: String = "21m00Tcm4TlvDq8ikWAM"
+    
+    @ObservationIgnored
+    @AppStorage("elevenLabsModelID") var elevenLabsModelID: String = "eleven_flash_v2_5"
 
     // MARK: - Google Cloud settings (tokens are short-lived, not persisted)
 
     var googleAccessToken: String = ""
-    var googleLanguageCode: String = "en-US"
     var googleVoiceName: String = "en-US-Chirp3-HD-Achernar"
-    var googleProjectID: String = ""
+    
+    var googleLanguageCode: String {
+        // Extract language code from voice name (e.g. "en-US" from "en-US-Chirp3-HD-Achernar")
+        let components = googleVoiceName.split(separator: "-")
+        if components.count >= 2 {
+            return "\(components[0])-\(components[1])"
+        }
+        return "en-US"
+    }
+    
+    @ObservationIgnored
+    @AppStorage("googleProjectID") var googleProjectID: String = ""
 
     // MARK: - Playback state
 
@@ -69,7 +82,7 @@ final class TTSViewModel {
         case .elevenLabs:
             return !elevenLabsAPIKey.isEmpty && !elevenLabsVoiceID.isEmpty
         case .googleCloud:
-            return !googleAccessToken.isEmpty
+            return !googleAccessToken.isEmpty && !googleProjectID.isEmpty
         }
     }
 
@@ -136,11 +149,12 @@ final class TTSViewModel {
         guard !googleAccessToken.isEmpty else {
             throw ValidationError.missingCredentials("Google access token is required.")
         }
+        guard !googleProjectID.isEmpty else {
+            throw ValidationError.missingCredentials("Google Project ID is required.")
+        }
         var config = GoogleCloudTTSConfiguration()
         config.voice = .init(languageCode: googleLanguageCode, name: googleVoiceName)
-        if !googleProjectID.isEmpty {
-            config.quotaProjectID = googleProjectID
-        }
+        config.quotaProjectID = googleProjectID
         let auth = PastedTokenAuthProvider(token: googleAccessToken)
         return GoogleCloudTTSAdapter(configuration: config, authProvider: auth)
     }
@@ -151,10 +165,11 @@ final class TTSViewModel {
             guard !elevenLabsAPIKey.isEmpty else {
                 throw ValidationError.missingCredentials("ElevenLabs API key is required.")
             }
-            let config = ElevenLabsConfiguration(
+            var config = ElevenLabsConfiguration(
                 apiKey: elevenLabsAPIKey,
                 voiceId: elevenLabsVoiceID
             )
+            config.modelId = elevenLabsModelID
             return ElevenLabsTTSAdapter(configuration: config)
 
         case .googleCloud:

--- a/Examples/StreamTTSDemo/Sources/StreamTTSDemo/TTSViewModel.swift
+++ b/Examples/StreamTTSDemo/Sources/StreamTTSDemo/TTSViewModel.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import StreamTTSCore
+import StreamTTSElevenLabs
+import StreamTTSGoogleCloud
+
+/// Which TTS provider to use.
+enum ProviderType: String, CaseIterable, Identifiable {
+    case elevenLabs = "ElevenLabs"
+    case googleCloud = "Google Cloud"
+
+    var id: String { rawValue }
+}
+
+/// Playback lifecycle state shown in the UI.
+enum PlaybackStatus: Equatable {
+    case ready
+    case connecting
+    case streaming
+    case playing
+    case finished
+    case error(String)
+}
+
+/// All business logic for the demo app.
+///
+/// Uses `@Observable` (macOS 14+) for a clean, modern integration with SwiftUI.
+/// Provider credentials are persisted via `@AppStorage` where appropriate.
+@MainActor
+@Observable
+final class TTSViewModel {
+    // MARK: - Provider selection
+
+    var selectedProvider: ProviderType = .elevenLabs
+
+    // MARK: - ElevenLabs settings
+
+    @ObservationIgnored
+    @AppStorage("elevenLabsAPIKey") var elevenLabsAPIKey: String = ""
+
+    @ObservationIgnored
+    @AppStorage("elevenLabsVoiceID") var elevenLabsVoiceID: String = "21m00Tcm4TlvDq8ikWAM"
+
+    // MARK: - Google Cloud settings (tokens are short-lived, not persisted)
+
+    var googleAccessToken: String = ""
+    var googleLanguageCode: String = "en-US"
+    var googleVoiceName: String = "en-US-Chirp3-HD-Achernar"
+    var googleProjectID: String = ""
+
+    // MARK: - Playback state
+
+    var inputText: String = "Hello! This is a test of the StreamTTS library. Each sentence is streamed separately to simulate real-time LLM output. The audio should start playing before all text has been sent."
+    var status: PlaybackStatus = .ready
+
+    var isPlaying: Bool {
+        switch status {
+        case .connecting, .streaming, .playing:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether the Speak button should be enabled.
+    var canSpeak: Bool {
+        if isPlaying { return false }
+        if inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return false }
+        switch selectedProvider {
+        case .elevenLabs:
+            return !elevenLabsAPIKey.isEmpty && !elevenLabsVoiceID.isEmpty
+        case .googleCloud:
+            return !googleAccessToken.isEmpty
+        }
+    }
+
+    // MARK: - Private state
+
+    private var playbackTask: Task<Void, Never>?
+    private var controller: StreamingTTSController?
+
+    // MARK: - Actions
+
+    /// Creates the appropriate provider, starts the pipeline, and streams text
+    /// in sentence-sized chunks with simulated delays.
+    func speak() {
+        let text = inputText
+        playbackTask = Task {
+            do {
+                status = .connecting
+
+                let provider = try createProvider()
+                let ctrl = StreamingTTSController(provider: provider)
+                self.controller = ctrl
+
+                try await ctrl.start()
+                status = .streaming
+
+                // Simulate LLM-style streaming: yield one sentence at a time.
+                let sentences = text.split(separator: ".", omittingEmptySubsequences: true)
+                for sentence in sentences {
+                    if Task.isCancelled { break }
+                    ctrl.yield(text: String(sentence).trimmingCharacters(in: .whitespaces) + ". ")
+                    try await Task.sleep(for: .milliseconds(200))
+                }
+
+                ctrl.finish()
+                status = .playing
+
+                await ctrl.waitUntilFinished()
+                if !Task.isCancelled {
+                    status = .finished
+                }
+            } catch is CancellationError {
+                status = .ready
+            } catch {
+                status = .error(error.localizedDescription)
+            }
+
+            self.controller = nil
+        }
+    }
+
+    /// Immediately cancels playback and tears down the connection.
+    func stop() {
+        controller?.cancel()
+        controller = nil
+        playbackTask?.cancel()
+        playbackTask = nil
+        status = .ready
+    }
+
+    // MARK: - Provider factory
+
+    @available(macOS 15.0, *)
+    private func makeGoogleProvider() throws -> any TTSProvider {
+        guard !googleAccessToken.isEmpty else {
+            throw ValidationError.missingCredentials("Google access token is required.")
+        }
+        var config = GoogleCloudTTSConfiguration()
+        config.voice = .init(languageCode: googleLanguageCode, name: googleVoiceName)
+        if !googleProjectID.isEmpty {
+            config.quotaProjectID = googleProjectID
+        }
+        let auth = PastedTokenAuthProvider(token: googleAccessToken)
+        return GoogleCloudTTSAdapter(configuration: config, authProvider: auth)
+    }
+
+    private func createProvider() throws -> any TTSProvider {
+        switch selectedProvider {
+        case .elevenLabs:
+            guard !elevenLabsAPIKey.isEmpty else {
+                throw ValidationError.missingCredentials("ElevenLabs API key is required.")
+            }
+            let config = ElevenLabsConfiguration(
+                apiKey: elevenLabsAPIKey,
+                voiceId: elevenLabsVoiceID
+            )
+            return ElevenLabsTTSAdapter(configuration: config)
+
+        case .googleCloud:
+            guard #available(macOS 15.0, *) else {
+                throw ValidationError.unsupportedPlatform(
+                    "Google Cloud TTS requires macOS 15.0 or later."
+                )
+            }
+            return try makeGoogleProvider()
+        }
+    }
+}
+
+/// Validation errors surfaced to the UI before attempting a network call.
+enum ValidationError: LocalizedError {
+    case missingCredentials(String)
+    case unsupportedPlatform(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingCredentials(let message): return message
+        case .unsupportedPlatform(let message): return message
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ It decouples network-level TTS ingestion from Core Audio hardware rendering. Thi
 
 Add StreamTTS to your Swift project using the Swift Package Manager. In your `Package.swift` file, add:
 
-<!-- TODO: Replace with actual repo URL before publishing -->
 ```swift
 dependencies: [
-    .package(url: "https://github.com/your-repo/StreamTTS.git", from: "1.0.0")
+    .package(url: "https://github.com/joostmbakker/StreamTTS.git", from: "1.0.0")
 ]
 ```
 
@@ -31,6 +30,23 @@ You can selectively import what you need:
 ---
 
 ## Usage
+
+### Quick Start
+
+If you have the full text upfront, use the `speak` convenience method:
+
+```swift
+import StreamTTSCore
+import StreamTTSElevenLabs
+
+let config = ElevenLabsConfiguration(apiKey: "YOUR_API_KEY", voiceId: "21m00Tcm4TlvDq8ikWAM")
+let provider = ElevenLabsTTSAdapter(configuration: config)
+
+let controller = StreamingTTSController(provider: provider)
+try await controller.speak("Hello, world!")
+```
+
+For incremental streaming (e.g., yielding chunks from an LLM response as they arrive), use the `start/yield/finish` flow shown below.
 
 ### 1. ElevenLabs
 

--- a/Sources/StreamTTSCore/StreamingTTSController.swift
+++ b/Sources/StreamTTSCore/StreamingTTSController.swift
@@ -84,4 +84,25 @@ public final class StreamingTTSController: @unchecked Sendable {
     public func waitUntilFinished() async {
         await pipeline.waitUntilFinished()
     }
+    
+    /// Synthesizes and plays back a single string of text.
+    ///
+    /// This is a convenience wrapper around the manual `start() → yield(text:) → finish()`
+    /// lifecycle. It starts the pipeline, sends the entire text as a single chunk, signals
+    /// completion, and waits for all audio to finish playing before returning.
+    ///
+    /// Use this when you have the full text available upfront. For incremental streaming
+    /// (e.g., yielding chunks from an LLM response), use `start()`, `yield(text:)`,
+    /// `finish()`, and `waitUntilFinished()` instead.
+    ///
+    /// - Parameter text: The text to synthesize and play.
+    /// - Throws: `StreamTTSError.alreadyStarted` if the controller has already been started,
+    ///           `StreamTTSError.alreadyCancelled` if the controller was cancelled,
+    ///           or any error from the provider or audio pipeline.
+    public func speak(_ text: String) async throws {
+        try await start()
+        yield(text: text)
+        finish()
+        await waitUntilFinished()
+    }
 }

--- a/Tests/StreamTTSCoreTests/StreamingTTSControllerTests.swift
+++ b/Tests/StreamTTSCoreTests/StreamingTTSControllerTests.swift
@@ -70,6 +70,70 @@ final class StreamingTTSControllerTests: XCTestCase {
         await controller.waitUntilFinished()
     }
     
+    // MARK: - speak() convenience method tests
+    
+    func testSpeakSingleString() async throws {
+        let provider = MockTTSProvider(sampleRate: 24000, frequency: 440)
+        let controller = StreamingTTSController(provider: provider)
+        
+        try await controller.speak("Hello, world!")
+        
+        // Verify the provider received exactly one chunk with the full text
+        XCTAssertEqual(provider.receivedChunkCount, 1)
+        XCTAssertEqual(provider.receivedChunks, ["Hello, world!"])
+    }
+    
+    func testSpeakReturnsAfterPlayback() async throws {
+        let provider = MockTTSProvider(sampleRate: 24000, frequency: 440)
+        let controller = StreamingTTSController(provider: provider)
+        
+        let startTime = ContinuousClock.now
+        try await controller.speak("Test")
+        let elapsed = ContinuousClock.now - startTime
+        
+        // The mock generates 0.1s of audio + 10ms simulated latency per chunk,
+        // so speak() should take a measurable amount of time before returning.
+        XCTAssertGreaterThan(elapsed, .zero, "speak() should wait for playback to complete")
+    }
+    
+    func testSpeakOnAlreadyStartedControllerThrows() async throws {
+        let provider = MockTTSProvider(sampleRate: 24000, frequency: 440)
+        let controller = StreamingTTSController(provider: provider)
+        
+        try await controller.start()
+        
+        do {
+            try await controller.speak("Should fail")
+            XCTFail("Expected alreadyStarted error")
+        } catch let error as StreamTTSError {
+            guard case .alreadyStarted = error else {
+                XCTFail("Expected .alreadyStarted, got \(error)")
+                return
+            }
+        }
+        
+        // Clean up the first start
+        controller.finish()
+        await controller.waitUntilFinished()
+    }
+    
+    func testSpeakOnCancelledControllerThrows() async throws {
+        let provider = MockTTSProvider(sampleRate: 24000, frequency: 440)
+        let controller = StreamingTTSController(provider: provider)
+        
+        controller.cancel()
+        
+        do {
+            try await controller.speak("Should fail")
+            XCTFail("Expected alreadyCancelled error")
+        } catch let error as StreamTTSError {
+            guard case .alreadyCancelled = error else {
+                XCTFail("Expected .alreadyCancelled, got \(error)")
+                return
+            }
+        }
+    }
+    
     func testYieldBeforeStartIsDropped() async throws {
         // Before start() is called, the text continuation is nil,
         // so yield calls are silently dropped. This is documented behavior.


### PR DESCRIPTION
## Release Summary

This PR merges the accumulated features and fixes from `dev` into `main`. 

### Key Changes
- **New Feature**: Added a `speak()` convenience method to `StreamingTTSController` for easier text streaming.
- **New App**: Added the `StreamTTSDemo` macOS app as a standalone SPM executable with proper window activation and keyboard focus.
- **Fixes & Improvements**: Fixed silent playback failures for Google Cloud TTS in the demo app by making the Project ID mandatory. Also added convenient model selection dropdowns for both ElevenLabs and Google Cloud TTS.